### PR TITLE
Language name search: Avoid searching for very long search keys

### DIFF
--- a/data/LanguageNameSearch.php
+++ b/data/LanguageNameSearch.php
@@ -41,6 +41,11 @@ class LanguageNameSearch {
 		$results = [];
 		$searchKey = mb_strtolower( $searchKey );
 
+		if ( mb_strlen( $searchKey ) > 100 ) {
+			// Searching with long search keys for language names is not useful. So, return early.
+			return [];
+		}
+
 		// Always prefer exact language code match
 		if ( Language::isKnownLanguageTag( $searchKey ) ) {
 			$name = mb_strtolower( Language::fetchLanguageName( $searchKey, $userLanguage ) );


### PR DESCRIPTION
Such searches are not useful and unnecessarily creates processing load.

The length limit 100 should cover the longest language names.

Bug: T293749
Change-Id: Ide32704cca578b9aecbce34bdcc0ac25c2a09a4d
(cherry picked from commit 613b8ae5ba8f389c2e0fde60099901fa97ac3cef)